### PR TITLE
Store and verify auth token after login

### DIFF
--- a/Backend/controllers/authController.js
+++ b/Backend/controllers/authController.js
@@ -36,7 +36,14 @@ exports.login = async (req, res) => {
 
   const token = jwt.sign({ id: user._id }, JWT_SECRET, { expiresIn: JWT_EXPIRES });
   res.cookie('token', token, cookieOpts());
-  res.json({ success: true });
+
+  const userData = {
+    id: user._id,
+    name: user.name,
+    email: user.email,
+  };
+
+  res.json({ success: true, token, user: userData });
 };
 
 exports.logout = async (req, res) => {
@@ -51,11 +58,30 @@ exports.me = async (req, res) => {
   res.json({ success: true, user: u });
 };
 
-authController.verify = async (req, res) => {
-    try {
-        // The auth middleware already verified the token
-        res.json({ success: true, user: req.user });
-    } catch (error) {
-        res.status(401).json({ success: false, message: 'Invalid token' });
+exports.verify = async (req, res) => {
+  try {
+    const authHeader = req.headers.authorization || '';
+    let token = null;
+
+    if (authHeader.startsWith('Bearer ')) {
+      token = authHeader.slice(7);
+    } else if (req.cookies?.token) {
+      token = req.cookies.token;
     }
+
+    if (!token) {
+      return res.status(401).json({ success: false, message: 'No token provided' });
+    }
+
+    const decoded = jwt.verify(token, JWT_SECRET);
+    const user = await Police.findById(decoded.id).lean();
+    if (!user) {
+      return res.status(404).json({ success: false, message: 'User not found' });
+    }
+    delete user.password;
+
+    res.json({ success: true, user });
+  } catch (error) {
+    res.status(401).json({ success: false, message: 'Invalid token' });
+  }
 };

--- a/Backend/routes/authRoutes.js
+++ b/Backend/routes/authRoutes.js
@@ -1,10 +1,11 @@
 // Backend/routes/authRoutes.js
-const router = require('express').Router();
+const express = require('express');
+const router = express.Router();
 const auth = require('../middlewares/auth');
 const ctrl = require('../controllers/authController');
 
 router.post('/login', ctrl.login);
 router.post('/logout', ctrl.logout);
 router.get('/me', auth, ctrl.me);
-router.get('/verify', auth, ctrl.verify);
+router.get('/verify', ctrl.verify);
 module.exports = router;

--- a/FrontEnd/Dashboard/dashboard.js
+++ b/FrontEnd/Dashboard/dashboard.js
@@ -1,4 +1,8 @@
 // dashboard.js - Fixed version with proper authentication handling
+const API_BASE = (typeof window !== 'undefined' && window.API_BASE)
+    ? window.API_BASE
+    : 'http://localhost:5000';
+
 document.addEventListener('DOMContentLoaded', function() {
     // Add a small delay to ensure token is stored after redirect
     setTimeout(() => {
@@ -30,7 +34,7 @@ document.addEventListener('DOMContentLoaded', function() {
 // Function to verify token with server
 async function verifyToken(token) {
     try {
-        const response = await fetch('/api/auth/verify', {
+        const response = await fetch(`${API_BASE}/api/auth/verify`, {
             headers: {
                 'Authorization': `Bearer ${token}`
             }

--- a/FrontEnd/login.js
+++ b/FrontEnd/login.js
@@ -24,6 +24,12 @@ form?.addEventListener('submit', async (e) => {
   submit.disabled = false;
 
   if (ok) {
+    if (data?.token) {
+      localStorage.setItem('authToken', data.token);
+    }
+    if (data?.user) {
+      localStorage.setItem('user', JSON.stringify(data.user));
+    }
     location.replace('/FrontEnd/Dashboard/dashboard.html');
   } else {
     showError((data && (data.message || data.error)) || 'Invalid email or password');

--- a/FrontEnd/shared/api.js
+++ b/FrontEnd/shared/api.js
@@ -17,16 +17,18 @@ function url(p) {
 
 
 export async function api(path, { method = 'GET', body, headers } = {}) {
-
   const opts = {
-
     method,
-
     credentials: 'include',
-
     headers: { 'Content-Type': 'application/json', ...(headers || {}) },
-
   };
+  // Attach auth token from localStorage if available
+  try {
+    const token = typeof window !== 'undefined' && window.localStorage.getItem('authToken');
+    if (token) {
+      opts.headers.Authorization = `Bearer ${token}`;
+    }
+  } catch (_) {}
 
   if (body !== undefined) opts.body = JSON.stringify(body);
 


### PR DESCRIPTION
## Summary
- Let verify endpoint accept auth tokens from headers or cookies
- Serve auth routes with standard Express router style and expose verify without auth middleware
- Send stored auth token on frontend API calls and use consistent URL for dashboard verification

## Testing
- `npm test` (fails: Missing script "test")
- `node Backend/server.js`


------
https://chatgpt.com/codex/tasks/task_e_68b2bafccef08321856a5831bf32851b